### PR TITLE
fix-issue46 多盲还原时限的备注看不清  改为白色

### DIFF
--- a/public/f/less/styles.less
+++ b/public/f/less/styles.less
@@ -1344,3 +1344,8 @@ body.live.disconnected {
     font-weight: bold;
   }
 }
+
+.concise-schedule td.event-333mbf span.comment {
+  color: white;
+  font-weight: bold;
+}


### PR DESCRIPTION
add space 2333
#46 @Baiqiang 

![image](https://user-images.githubusercontent.com/7088329/49432951-cc31ef80-f7eb-11e8-81ff-e2442ed23740.png)
