### PR TITLE
feat: centralize dual-round podium ranking in LiveResult

### DIFF
--- a/protected/models/Competition.php
+++ b/protected/models/Competition.php
@@ -1936,9 +1936,9 @@ class Competition extends ActiveRecord {
 		$podiums = [];
 		$greaterChinaPodiums = [];
 		foreach ($eventRounds as $eventRound) {
-			$format = $this->getPodiumResultFormat($eventRound);
+			$format = LiveResult::getRankingFormat($eventRound->format);
 			$results = $this->getLivePodiumRoundResults($eventRound);
-			$this->assignPodiumPositions($results, $format);
+			LiveResult::assignPositions($results, $format);
 			foreach ($results as $result) {
 				if ($result->pos <= $this->podiums_num) {
 					$podiums[$eventRound->event][] = clone $result;
@@ -1949,7 +1949,7 @@ class Competition extends ActiveRecord {
 			}
 		}
 		foreach ($greaterChinaPodiums as $event=>$results) {
-			$this->assignPodiumPositions($results, 'a');
+			LiveResult::assignPositions($results, 'a');
 			$temp = [];
 			foreach ($results as $result) {
 				if ($result->pos > $this->podiums_num) {
@@ -2024,7 +2024,7 @@ class Competition extends ActiveRecord {
 					}
 				}
 				foreach ($temp as $group=>$results) {
-					$this->assignPodiumPositions($results, 'a');
+					LiveResult::assignPositions($results, 'a');
 					foreach ($results as $result) {
 						if ($result->pos > $this->podiums_num) {
 							break;
@@ -2045,20 +2045,6 @@ class Competition extends ActiveRecord {
 			'podiums'=>$podiums,
 			'greaterChinaPodiums'=>$greaterChinaPodiums,
 		];
-	}
-
-	private function getPodiumResultFormat($eventRound) {
-		switch ($eventRound->format) {
-			case '1':
-			case '2':
-			case '3':
-			case '5':
-				return 'b';
-			case 'a':
-			case 'm':
-			default:
-				return 'a';
-		}
 	}
 
 	private function getCombinedPodiumResultModels($round1, $round2) {
@@ -2091,13 +2077,10 @@ class Competition extends ActiveRecord {
 	 */
 	private function getLivePodiumRoundResults($eventRound) {
 		$dualRounds = $eventRound->dualRounds;
-		if ($dualRounds !== array()
-			&& $dualRounds[0]->isClosed
-			&& $dualRounds[1]->isClosed
-			&& $eventRound->id == $dualRounds[1]->id) {
+		if (LiveResult::isLiveCombinedDualPodiumRound($eventRound, $dualRounds)) {
 			return $this->getCombinedPodiumResultModels($dualRounds[0], $dualRounds[1]);
 		}
-		$format = $this->getPodiumResultFormat($eventRound);
+		$format = LiveResult::getRankingFormat($eventRound->format);
 		$order = $format == 'b' ? 'best ASC' : 'average > 0 DESC, average ASC, best ASC';
 		return LiveResult::model()->with('user')->findAllByAttributes([
 			'competition_id'=>$this->id,
@@ -2122,36 +2105,6 @@ class Competition extends ActiveRecord {
 			'condition'=>'best > 0',
 			'order'=>'average > 0 DESC, average ASC, best ASC',
 		]);
-	}
-
-	private function assignPodiumPositions(&$results, $format) {
-		$count = 0;
-		$lastBest = 0;
-		$lastAverage = 0;
-		foreach ($results as $i=>&$result) {
-			if ($format == 'a') {
-				if ($result->average != $lastAverage) {
-					$lastAverage = $result->average;
-					$lastBest = $result->best;
-					$result->pos = $i + 1;
-					$count = $i;
-				} elseif ($result->best != $lastBest) {
-					$lastBest = $result->best;
-					$result->pos = $i + 1;
-					$count = $i;
-				} else {
-					$result->pos = $count + 1;
-				}
-			} else {
-				if ($result->best != $lastBest) {
-					$lastBest = $result->best;
-					$result->pos = $i + 1;
-					$count = $i;
-				} else {
-					$result->pos = $count + 1;
-				}
-			}
-		}
 	}
 
 	public function computeRecords($event, $type = 'best') {

--- a/protected/models/LiveEventRound.php
+++ b/protected/models/LiveEventRound.php
@@ -92,7 +92,6 @@ class LiveEventRound extends ActiveRecord {
 	 * @return array
 	 */
 	public static function getCombinedRanking($round1, $round2) {
-		$format = $round1->format;
 		$byNumber = array();
 		foreach ($round1->allResults as $result) {
 			$byNumber[$result->number]['r1'] = $result;
@@ -100,42 +99,16 @@ class LiveEventRound extends ActiveRecord {
 		foreach ($round2->allResults as $result) {
 			$byNumber[$result->number]['r2'] = $result;
 		}
-		$rows = array();
-		foreach ($byNumber as $number=>$pair) {
-			$r1 = isset($pair['r1']) ? $pair['r1'] : null;
-			$r2 = isset($pair['r2']) ? $pair['r2'] : null;
-			if ($r1 === null && $r2 === null) {
-				continue;
-			}
-			if ($r1 === null) {
-				$better = $r2;
-				$betterRound = 'r2';
-			} elseif ($r2 === null) {
-				$better = $r1;
-				$betterRound = 'r1';
-			} elseif (LiveResult::compareResults($r1, $r2, $format) <= 0) {
-				$better = $r1;
-				$betterRound = 'r1';
-			} else {
-				$better = $r2;
-				$betterRound = 'r2';
-			}
-			$rows[] = array(
-				'number'=>$number,
-				'r1'=>$r1,
-				'r2'=>$r2,
-				'better'=>$better,
-				'betterRound'=>$betterRound,
+		$ranked = LiveResult::rankCombinedPairs($byNumber, $round1->format, array('LiveResult', 'tieBreakByNumberKey'), false);
+		return array_map(function($row) {
+			return array(
+				'number'=>$row['key'],
+				'r1'=>$row['r1'],
+				'r2'=>$row['r2'],
+				'better'=>$row['better'],
+				'betterRound'=>$row['betterRound'],
 			);
-		}
-		usort($rows, function($a, $b) use($format) {
-			$temp = LiveResult::compareResults($a['better'], $b['better'], $format);
-			if ($temp == 0) {
-				$temp = $a['number'] - $b['number'];
-			}
-			return $temp;
-		});
-		return $rows;
+		}, $ranked);
 	}
 
 	public function removeResults() {

--- a/protected/models/LiveResult.php
+++ b/protected/models/LiveResult.php
@@ -131,6 +131,176 @@ class LiveResult extends ActiveRecord {
 		return $temp;
 	}
 
+	public static function getRankingFormat($formatId) {
+		switch ($formatId) {
+			case '1':
+			case '2':
+			case '3':
+			case '5':
+				return 'b';
+			default:
+				return 'a';
+		}
+	}
+
+	public static function assignPositions(&$results, $format) {
+		$format = self::getRankingFormat($format);
+		$count = 0;
+		$lastBest = 0;
+		$lastAverage = 0;
+		foreach ($results as $i=>&$result) {
+			$average = is_array($result) ? $result['average'] : $result->average;
+			$best = is_array($result) ? $result['best'] : $result->best;
+			if ($format == 'a') {
+				if ($average != $lastAverage) {
+					$lastAverage = $average;
+					$lastBest = $best;
+					$pos = $i + 1;
+					$count = $i;
+				} elseif ($best != $lastBest) {
+					$lastBest = $best;
+					$pos = $i + 1;
+					$count = $i;
+				} else {
+					$pos = $count + 1;
+				}
+			} else {
+				if ($best != $lastBest) {
+					$lastBest = $best;
+					$pos = $i + 1;
+					$count = $i;
+				} else {
+					$pos = $count + 1;
+				}
+			}
+			if (is_array($result)) {
+				$result['pos'] = $pos;
+			} else {
+				$result->pos = $pos;
+			}
+		}
+	}
+
+	/**
+	 * Live path: combined dual podiums when the official c/f round is the
+	 * second dual round and both dual rounds are closed.
+	 */
+	public static function isLiveCombinedDualPodiumRound($eventRound, $dualRounds = null) {
+		if ($dualRounds === null) {
+			$dualRounds = $eventRound->dualRounds;
+		}
+		return count($dualRounds) >= 2
+			&& $dualRounds[0]->isClosed
+			&& $dualRounds[1]->isClosed
+			&& $eventRound->id == $dualRounds[1]->id;
+	}
+
+	/**
+	 * WCA path: combined dual podiums when the second dual round is c/f and no
+	 * separate c/f round follows (e.g. 333fm 1+f yes, 1+2+f no).
+	 *
+	 * @param array $roundRanks map roundTypeId => rank
+	 */
+	public static function isWcaCombinedDualPodium($roundRanks, $dualRound2) {
+		if (!in_array($dualRound2, array('c', 'f'), true) || !isset($roundRanks[$dualRound2])) {
+			return false;
+		}
+		$dualRound2Rank = $roundRanks[$dualRound2];
+		foreach ($roundRanks as $roundTypeId=>$rank) {
+			if (in_array($roundTypeId, array('c', 'f'), true)
+				&& $roundTypeId !== $dualRound2
+				&& $rank > $dualRound2Rank) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Pick the better of two dual-round results (WCA Reg 9v4).
+	 * @return array{better:mixed,betterRound:string}|null
+	 */
+	private static function pickBetterDualResult($r1, $r2, $format) {
+		if ($r1 === null && $r2 === null) {
+			return null;
+		}
+		if ($r1 === null) {
+			return array('better'=>$r2, 'betterRound'=>'r2');
+		}
+		if ($r2 === null) {
+			return array('better'=>$r1, 'betterRound'=>'r1');
+		}
+		if (self::compareResults(self::resultForCompare($r1), self::resultForCompare($r2), $format) <= 0) {
+			return array('better'=>$r1, 'betterRound'=>'r1');
+		}
+		return array('better'=>$r2, 'betterRound'=>'r2');
+	}
+
+	/**
+	 * Combine dual-round pairs per competitor, pick the better result, optionally
+	 * filter invalid bests, and sort best to worst.
+	 *
+	 * @param array $pairsByCompetitor competitorKey => ['r1'=>..., 'r2'=>...]
+	 * @param callable $tieBreaker function(array $a, array $b): int
+	 * @return array list of ['key', 'r1', 'r2', 'better', 'betterRound']
+	 */
+	public static function rankCombinedPairs($pairsByCompetitor, $format, $tieBreaker, $requireValidBest = true) {
+		$format = self::getRankingFormat($format);
+		$combined = array();
+		foreach ($pairsByCompetitor as $key=>$pair) {
+			$r1 = isset($pair['r1']) ? $pair['r1'] : null;
+			$r2 = isset($pair['r2']) ? $pair['r2'] : null;
+			$picked = self::pickBetterDualResult($r1, $r2, $format);
+			if ($picked === null) {
+				continue;
+			}
+			$better = $picked['better'];
+			if ($requireValidBest) {
+				$best = is_array($better) ? $better['best'] : $better->best;
+				if ($best <= 0) {
+					continue;
+				}
+			}
+			$combined[] = array(
+				'key'=>$key,
+				'r1'=>$r1,
+				'r2'=>$r2,
+				'better'=>$better,
+				'betterRound'=>$picked['betterRound'],
+			);
+		}
+		usort($combined, function($a, $b) use ($format, $tieBreaker) {
+			$temp = self::compareResults(
+				self::resultForCompare($a['better']),
+				self::resultForCompare($b['better']),
+				$format
+			);
+			if ($temp != 0) {
+				return $temp;
+			}
+			return $tieBreaker($a, $b);
+		});
+		return $combined;
+	}
+
+	public static function tieBreakByNumberKey($a, $b) {
+		return $a['key'] - $b['key'];
+	}
+
+	public static function tieBreakByCompetitorKey($a, $b) {
+		return strcmp($a['key'], $b['key']);
+	}
+
+	private static function resultForCompare($result) {
+		if (is_array($result)) {
+			return (object) array(
+				'best'=>(int) $result['best'],
+				'average'=>(int) $result['average'],
+			);
+		}
+		return $result;
+	}
+
 	public function getCalculatedPos() {
 		if ($this->best == 0) {
 			return '-';

--- a/protected/models/wca/Competitions.php
+++ b/protected/models/wca/Competitions.php
@@ -77,10 +77,6 @@ class Competitions extends ActiveRecord {
 			'condition'=>'best > 0',
 			'order'=>'event.`rank`, round.`rank`, t.pos'
 		));
-		$events = array();
-		foreach ($winners as $result) {
-			$events[$result->event_id] = $result->event_id;
-		}
 		$top3 = Results::model()->with(array(
 			'person',
 			'person.country',
@@ -173,6 +169,15 @@ class Competitions extends ActiveRecord {
 		), array(
 			'order'=>'event.`rank`, round.`rank`, t.group_id, t.is_extra, t.scramble_num',
 		));
+		list($resultsByEvent, $roundRanksByEvent) = $this->indexResultsByEvent($all);
+		$dualEvents = $this->getDualEventRoundTypes($id, $roundRanksByEvent);
+		if ($dualEvents !== array()) {
+			$this->applyDualRoundPodiums($winners, $top3, $resultsByEvent, $dualEvents);
+		}
+		$events = array();
+		foreach ($winners as $result) {
+			$events[$result->event_id] = $result->event_id;
+		}
 		return array(
 			'winners'=>$winners,
 			'top3'=>$top3,
@@ -443,6 +448,128 @@ class Competitions extends ActiveRecord {
 				'defaultOrder'=>'t.year DESC, t.month DESC, t.day DESC, t.end_month DESC, t.end_day DESC',
 			),
 		));
+	}
+
+	private function indexResultsByEvent($all) {
+		$resultsByEvent = array();
+		$roundRanksByEvent = array();
+		foreach ($all as $result) {
+			if ($result->round === null) {
+				continue;
+			}
+			$eventId = $result->event_id;
+			$resultsByEvent[$eventId][] = $result;
+			$roundRanksByEvent[$eventId][$result->round_type_id] = $result->round->rank;
+		}
+		return array($resultsByEvent, $roundRanksByEvent);
+	}
+
+	private function getDualEventRoundTypes($wcaCompetitionId, $roundRanksByEvent) {
+		$competition = $this->c;
+		if ($competition === null) {
+			$competition = Competition::model()->findByAttributes(array(
+				'wca_competition_id'=>$wcaCompetitionId,
+				'status'=>Competition::STATUS_SHOW,
+			));
+		}
+		if ($competition === null) {
+			return array();
+		}
+		$dualEvents = array();
+		foreach (CompetitionEvent::model()->findAllByAttributes(array(
+			'competition_id'=>$competition->id,
+			'dual'=>1,
+		)) as $competitionEvent) {
+			$eventId = $competitionEvent->event;
+			if (!isset($roundRanksByEvent[$eventId])) {
+				continue;
+			}
+			$roundTypes = $this->resolveDualRoundTypes($roundRanksByEvent[$eventId]);
+			if ($roundTypes === null) {
+				continue;
+			}
+			if (!LiveResult::isWcaCombinedDualPodium($roundRanksByEvent[$eventId], $roundTypes[1])) {
+				continue;
+			}
+			$dualEvents[$eventId] = $roundTypes;
+		}
+		return $dualEvents;
+	}
+
+	private function resolveDualRoundTypes($roundRanks) {
+		if (count($roundRanks) < 2) {
+			return null;
+		}
+		$sortedRanks = $roundRanks;
+		asort($sortedRanks);
+		$roundTypes = array_map('strval', array_keys($sortedRanks));
+		return array($roundTypes[0], $roundTypes[1]);
+	}
+
+	private function buildCombinedDualResults($eventResults, $round1, $round2) {
+		$byPerson = array();
+		$format = null;
+		foreach ($eventResults as $result) {
+			if ($result->round_type_id === $round1) {
+				$byPerson[$result->person_id]['r1'] = $result;
+				if ($format === null) {
+					$format = $result->format_id;
+				}
+			} elseif ($result->round_type_id === $round2) {
+				$byPerson[$result->person_id]['r2'] = $result;
+				if ($format === null) {
+					$format = $result->format_id;
+				}
+			}
+		}
+		if ($format === null) {
+			return array(array(), null);
+		}
+		$ranked = LiveResult::rankCombinedPairs($byPerson, $format, array('LiveResult', 'tieBreakByCompetitorKey'));
+		return array(array_column($ranked, 'better'), $format);
+	}
+
+	private function applyDualRoundPodiums(&$winners, &$top3, $resultsByEvent, $dualEvents) {
+		$dualEventIds = array_flip(array_keys($dualEvents));
+		$winners = array_values(array_filter($winners, function($result) use ($dualEventIds) {
+			return !isset($dualEventIds[$result->event_id]);
+		}));
+		$top3 = array_values(array_filter($top3, function($result) use ($dualEventIds) {
+			return !isset($dualEventIds[$result->event_id]);
+		}));
+		foreach ($dualEvents as $eventId=>$roundTypes) {
+			list($round1, $round2) = $roundTypes;
+			$eventResults = isset($resultsByEvent[$eventId]) ? $resultsByEvent[$eventId] : array();
+			list($combined, $format) = $this->buildCombinedDualResults($eventResults, $round1, $round2);
+			if ($combined === array()) {
+				continue;
+			}
+			LiveResult::assignPositions($combined, $format);
+			foreach ($combined as $result) {
+				if ($result->pos > 3) {
+					continue;
+				}
+				$podiumResult = clone $result;
+				if ($result->pos === 1) {
+					$winners[] = $podiumResult;
+				}
+				$top3[] = $podiumResult;
+			}
+		}
+		usort($winners, function($resultA, $resultB) {
+			$temp = $resultA->event->rank <=> $resultB->event->rank;
+			if ($temp === 0) {
+				$temp = $resultB->round->rank <=> $resultA->round->rank;
+			}
+			return $temp;
+		});
+		usort($top3, function($resultA, $resultB) {
+			$temp = $resultA->event->rank <=> $resultB->event->rank;
+			if ($temp === 0) {
+				$temp = $resultA->pos <=> $resultB->pos;
+			}
+			return $temp;
+		});
 	}
 
 	/**

--- a/protected/statistics/BestPodiums.php
+++ b/protected/statistics/BestPodiums.php
@@ -271,44 +271,17 @@ class BestPodiums extends Statistics {
 		return $results;
 	}
 
-	private static function compare333fmResults($a, $b) {
-		return LiveResult::compareResults(
-			(object) array('best'=>(int) $a['best'], 'average'=>(int) $a['average']),
-			(object) array('best'=>(int) $b['best'], 'average'=>(int) $b['average']),
-			'm'
-		);
-	}
-
 	private static function buildCombined333fmPodium($round1, $roundf) {
 		$byPerson = array();
 		foreach ($round1 as $result) {
 			$byPerson[$result['person_id']]['r1'] = $result;
 		}
 		foreach ($roundf as $result) {
-			$byPerson[$result['person_id']]['f'] = $result;
+			$byPerson[$result['person_id']]['r2'] = $result;
 		}
-		$combined = array();
-		foreach ($byPerson as $pair) {
-			$r1 = isset($pair['r1']) ? $pair['r1'] : null;
-			$rf = isset($pair['f']) ? $pair['f'] : null;
-			if ($r1 === null) {
-				$combined[] = $rf;
-			} elseif ($rf === null) {
-				$combined[] = $r1;
-			} elseif (self::compare333fmResults($r1, $rf) <= 0) {
-				$combined[] = $r1;
-			} else {
-				$combined[] = $rf;
-			}
-		}
-		usort($combined, function($a, $b) {
-			$temp = self::compare333fmResults($a, $b);
-			if ($temp != 0) {
-				return $temp;
-			}
-			return strcmp($a['person_id'], $b['person_id']);
-		});
-		self::assign333fmPositions($combined);
+		$ranked = LiveResult::rankCombinedPairs($byPerson, 'm', array('LiveResult', 'tieBreakByCompetitorKey'), false);
+		$combined = array_column($ranked, 'better');
+		LiveResult::assignPositions($combined, 'm');
 		return self::make333fmPodiumFromRanked($combined);
 	}
 
@@ -450,16 +423,6 @@ class BestPodiums extends Statistics {
 
 	private static function get333fmAttemptValues($result) {
 		return isset($result['attempt_values']) ? $result['attempt_values'] : array();
-	}
-
-	private static function assign333fmPositions(&$results) {
-		foreach ($results as $i=>&$result) {
-			if ($i > 0 && self::compare333fmResults($result, $results[$i - 1]) === 0) {
-				$result['pos'] = $results[$i - 1]['pos'];
-			} else {
-				$result['pos'] = $i + 1;
-			}
-		}
 	}
 
 	private static function getSelectSum($type) {


### PR DESCRIPTION
Unify live and WCA podium ranking with shared helpers, and show combined dual-round results on WCA result pages.